### PR TITLE
Update ship-builder.json

### DIFF
--- a/src/data/ship-builder.json
+++ b/src/data/ship-builder.json
@@ -499,7 +499,6 @@
 						"light"
 					],
 					"turret": [
-						"heavy",
 						"heavy"
 					]
 				},


### PR DESCRIPTION
The Cruiser frame should only have 1 heavy turret mount, not 2 (according to the Core Rulebook and aonsrd.)